### PR TITLE
fix: resolve screen scrolling issue in audio mode

### DIFF
--- a/src/infrastructure/video-player-service.ts
+++ b/src/infrastructure/video-player-service.ts
@@ -39,6 +39,8 @@ export class VideoPlayerService implements IVideoPlayerService {
             '--demuxer-readahead-secs=20',
             '--ytdl-raw-options-append=verbose=',
             '--ytdl-raw-options-append=retries=3',
+            '--no-terminal',
+            '--really-quiet',
           ];
           if (options?.audioOnly) {
             mpvArgs.push('--no-video');

--- a/src/ui/components/AudioPlayer.tsx
+++ b/src/ui/components/AudioPlayer.tsx
@@ -124,6 +124,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({
       borderStyle="round"
       borderColor={color || 'cyan'}
       padding={1}
+      marginX={1}
     >
       <Text bold color={color || 'green'}>
         {symbol ? `${symbol} ` : ''}Audio Player


### PR DESCRIPTION
- Add `marginX={1}` to AudioPlayer to prevent Ink layout glitches caused by terminal line wrapping at the edge.
- Suppress MPV standard output with `--no-terminal` and `--really-quiet` to prevent interfering with the UI rendering.

closes #34