### PR TITLE
ci: switch to OIDC authentication for npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
closes #61 