### PR TITLE
feat: add video summary feature using Gemini API

### DIFF
--- a/docs/designDocs/architecture.md
+++ b/docs/designDocs/architecture.md
@@ -35,7 +35,8 @@ src/
 │   ├── video-player-service.ts # 動画再生 (MPV/Browser)
 │   ├── config-repository.ts # 設定ファイル読み書き
 │   ├── cache-repository.ts # データキャッシュ (conf)
-│   └── spreadsheet-service.ts # Google Sheet CSV取得
+│   ├── spreadsheet-service.ts # Google Sheet CSV取得
+│   └── summarize-service.ts # 動画要約 (youtube-transcript + Google GenAI)
 ├── ui/               # プレゼンテーション層 (UI): Inkコンポーネント
 │   ├── App.tsx       # メインコンポーネント
 │   ├── components/   # 再利用可能なUI部品

--- a/docs/designDocs/data_models.md
+++ b/docs/designDocs/data_models.md
@@ -145,6 +145,8 @@ export interface ConfigSchema {
   creators: Creator[];
   /** YouTube Data API v3 Key (Optional) */
   youtubeApiToken?: string;
+  /** Google Gemini API Key (Optional) */
+  geminiApiKey?: string;
 }
 ```
 

--- a/docs/designDocs/features.md
+++ b/docs/designDocs/features.md
@@ -21,6 +21,9 @@
         - 実行時に最終確認のプロンプトが表示されます。(`y/N`)
         - 削除対象: 設定ファイル (`valiv-cli` 関連フォルダ)、キャッシュファイル
         - 注意: 登録済みのクリエイター情報やAPIトークンはすべて失われます。
+    - **Gemini API Key設定** (New):
+        - `init` 実行に、Google Gemini API Key の入力を求めます。（スキップ可能）
+        - 設定された場合、`check` コマンドで動画の要約機能が利用可能になります。
 - **使用法**: 
     - `valiv init`
     - `valiv init --clean`
@@ -101,6 +104,13 @@
 - **オプション**:
     - `--refresh` (`-r`): キャッシュを無視してデータを再取得します。
     - `--audio-only` (`-a`): 音声のみ再生します。
+    - `--summary` (`-s`): 選択した動画の要約を表示します。
+        - **要件**: `init` で Gemini API Key が設定されている必要があります。
+        - **動作**: 
+            - リストからエンターキーで動画を選択した際、通常の再生処理の代わりに要約処理を実行します。
+            - YouTubeの字幕データ (`youtube-transcript`) を取得します。
+            - Gemini API (`gemini-3-flash-preview`) を使用して内容を要約します。
+            - 要約結果をリストの上部に表示します。
     - `--debug` (`-d`): デバッグログを出力します。
 - **使用法**:
     - `valiv check`
@@ -180,6 +190,7 @@
 - **内容**: 
     - `creators`: 登録クリエイターのリスト
     - `youtubeApiToken`: (Optional) YouTube Data API Token
+    - `geminiApiKey`: (Optional) Google Gemini API Key
     - `googleSpreadsheetId`: (Optional) 統計情報を取得するための公開スプレッドシートID（未設定時はデフォルト値が使用されます）
 
 ## 統計情報データソース

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "axios": "^1.6.0",
         "commander": "^14.0.2",
         "conf": "^15.0.2",
@@ -21,7 +22,8 @@
         "node-mpv": "^1.5.0",
         "open": "^11.0.0",
         "react": "^19.2.1",
-        "rss-parser": "^3.13.0"
+        "rss-parser": "^3.13.0",
+        "youtube-transcript-plus": "^1.1.1"
       },
       "bin": {
         "valiv": "dist/cli.js"
@@ -739,6 +741,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1235,7 +1246,6 @@
       "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1246,7 +1256,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1296,7 +1305,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -1612,7 +1620,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2414,7 +2421,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2469,7 +2475,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2530,7 +2535,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3149,7 +3153,6 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-6.5.1.tgz",
       "integrity": "sha512-wF3j/DmkM8q5E+OtfdQhCRw8/0ahkc8CUTgEddxZzpEWPslu7YPL3t64MWRoI9m6upVGpfAg4ms2BBvxCdKRLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.2.0",
@@ -3947,7 +3950,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3997,7 +3999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4078,7 +4079,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4132,7 +4132,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4816,7 +4815,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4898,7 +4896,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5747,6 +5744,15 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/youtube-transcript-plus": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/youtube-transcript-plus/-/youtube-transcript-plus-1.1.1.tgz",
+      "integrity": "sha512-KmAcn7eBPMgSnPJosCaaRp6/eqOAXk9p5f5ExBf+aD0M74Hud5RzbwHVoFpR5wOS++QqrrFaFhq9eiaWqWDlXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "axios": "^1.6.0",
     "commander": "^14.0.2",
     "conf": "^15.0.2",
@@ -50,7 +51,8 @@
     "node-mpv": "^1.5.0",
     "open": "^11.0.0",
     "react": "^19.2.1",
-    "rss-parser": "^3.13.0"
+    "rss-parser": "^3.13.0",
+    "youtube-transcript-plus": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.0.2",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -66,6 +66,10 @@ program
   .option('-p, --playlist <path>', 'Path to uta_picker playlist CSV file')
   .option('-d, --debug', 'Enable debug logging to file')
   .option('-r, --refresh', 'Force refresh data')
+  .option(
+    '-s, --summary',
+    'Summarize the latest activity (requires Gemini API Key)',
+  )
   .option('--no-color-creator', 'Disable creator colors')
   .action((id, options) => {
     render(
@@ -76,6 +80,7 @@ program
         playlist={options.playlist}
         debug={options.debug}
         refresh={options.refresh}
+        summary={options.summary}
         disableColor={!options.colorCreator}
       />,
     );

--- a/src/domain/interfaces.ts
+++ b/src/domain/interfaces.ts
@@ -28,6 +28,14 @@ export interface IScheduleService {
   ): Promise<ScheduleEvent[]>;
 }
 
+export interface ISummarizeService {
+  summarizeVideo(
+    videoId: string,
+    apiKey: string,
+    onProgress?: (message: string) => void,
+  ): Promise<string>;
+}
+
 export interface IConfigRepository {
   getCreators(): Creator[];
   saveCreator(creator: Creator): void;
@@ -38,5 +46,8 @@ export interface IConfigRepository {
 
   getGoogleSpreadsheetId(): string | undefined;
   saveGoogleSpreadsheetId(id: string): void;
+
+  getGeminiApiKey(): string | undefined;
+  saveGeminiApiKey(key: string): void;
   getPath(): string;
 }

--- a/src/infrastructure/config-repository.ts
+++ b/src/infrastructure/config-repository.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SPREADSHEET_ID } from '../domain/constants.js';
 interface ConfigSchema {
   creators: Creator[];
   youtubeApiToken?: string;
+  geminiApiKey?: string;
   googleSpreadsheetId?: string;
 }
 
@@ -73,6 +74,14 @@ export class ConfigRepository implements IConfigRepository {
 
   saveGoogleSpreadsheetId(id: string): void {
     this.store.set('googleSpreadsheetId', id);
+  }
+
+  getGeminiApiKey(): string | undefined {
+    return this.store.get('geminiApiKey');
+  }
+
+  saveGeminiApiKey(key: string): void {
+    this.store.set('geminiApiKey', key);
   }
 
   getPath(): string {

--- a/src/infrastructure/summarize-service.ts
+++ b/src/infrastructure/summarize-service.ts
@@ -1,0 +1,173 @@
+import { ISummarizeService } from '../domain/interfaces.js';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { YoutubeTranscript } from 'youtube-transcript-plus';
+
+export class SummarizeService implements ISummarizeService {
+  async summarizeVideo(
+    videoId: string,
+    apiKey: string,
+    onProgress?: (message: string) => void,
+  ): Promise<string> {
+    // IDのクレンジング (RSS由来の yt:video: を削除)
+    const cleanVideoId = videoId.replace(/^yt:video:/, '');
+
+    try {
+      if (onProgress) onProgress('Fetching transcript...');
+
+      // まず日本語の字幕取得を試みる
+      let transcriptItems;
+      try {
+        transcriptItems = await YoutubeTranscript.fetchTranscript(
+          cleanVideoId,
+          {
+            lang: 'ja',
+          },
+        );
+        if (!transcriptItems || transcriptItems.length === 0) {
+          throw new Error('Japanese transcript empty');
+        }
+      } catch (e) {
+        // 日本語がない、または取得に失敗した場合はデフォルト（英語/自動生成など）を取得
+        try {
+          transcriptItems =
+            await YoutubeTranscript.fetchTranscript(cleanVideoId);
+        } catch (e2) {
+          const msg1 = e instanceof Error ? e.message : String(e);
+          const msg2 = e2 instanceof Error ? e2.message : String(e2);
+          return `字幕が見つかりませんでした。(Video ID: ${cleanVideoId})\nError(JA): ${msg1}\nError(Default): ${msg2}`;
+        }
+      }
+
+      if (!transcriptItems || transcriptItems.length === 0) {
+        // ライブラリで取得できなかった場合、自前実装のフォールバックを試みる
+        try {
+          if (onProgress) onProgress('Fetching transcript (fallback mode)...');
+          const manualText = await this.fetchManualTranscript(cleanVideoId);
+          if (manualText) {
+            // 手動取得成功
+            const fullText = manualText;
+
+            if (onProgress) onProgress('Generating summary with Gemini...');
+
+            // Gemini APIの初期化
+            const genAI = new GoogleGenerativeAI(apiKey);
+            const model = genAI.getGenerativeModel({
+              model: 'gemini-3-flash-preview',
+            });
+
+            const prompt = `以下のYouTube動画の字幕を要約してください。
+内容は日本語で出力してください。
+重要なポイントを箇条書きで3〜5点にまとめてください。
+
+---
+${fullText}
+`;
+            const result = await model.generateContent(prompt);
+            const response = await result.response;
+            return response.text();
+          }
+        } catch (manualError) {
+          const mErr =
+            manualError instanceof Error
+              ? manualError.message
+              : String(manualError);
+          return `字幕データが見つかりませんでした。(Video ID: ${cleanVideoId})
+考えられる原因: 動画に字幕がない、または自動生成中。
+(Library Result: Empty, Fallback Error: ${mErr})`;
+        }
+
+        return `字幕データが見つかりませんでした。(Video ID: ${cleanVideoId}) - Library returned empty`;
+      }
+
+      const fullText = transcriptItems.map((item) => item.text).join(' ');
+
+      if (onProgress) onProgress('Generating summary with Gemini...');
+
+      // Gemini APIの初期化
+      const genAI = new GoogleGenerativeAI(apiKey);
+      const model = genAI.getGenerativeModel({
+        model: 'gemini-3-flash-preview',
+      });
+
+      const prompt = `以下のYouTube動画の字幕を要約してください。
+内容は日本語で出力してください。
+重要なポイントを箇条書きで3〜5点にまとめてください。
+
+---
+${fullText}
+`;
+
+      const result = await model.generateContent(prompt);
+      const response = await result.response;
+      return response.text();
+    } catch (error) {
+      // エラーログは出さず、UIに表示するメッセージを返す
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes('Transcript is disabled')) {
+        return 'この動画では字幕が無効になっているため要約できません。';
+      }
+      return `要約中にエラーが発生しました: ${errorMessage}`;
+    }
+  }
+
+  private async fetchManualTranscript(videoId: string): Promise<string> {
+    const res = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7',
+      },
+    });
+    const html = await res.text();
+
+    // captionTracksを探す
+    const match = html.match(/"captionTracks":(\[.*?\])/);
+    if (!match) {
+      throw new Error('Caption tracks not found in HTML (Main regex failed)');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tracks = JSON.parse(match[1]) as any[];
+    // 日本語を探す (ja, ja-JP など)
+    let track = tracks.find((t) => t.languageCode === 'ja');
+    if (!track) {
+      track = tracks.find(
+        (t) => t.languageCode && t.languageCode.startsWith('ja'),
+      );
+    }
+    // なければデフォルト（どれでもいい、おそらく英語か自動生成）
+    if (!track && tracks.length > 0) {
+      track = tracks[0];
+    }
+
+    if (!track) {
+      throw new Error('No usable caption track found in extracted list');
+    }
+
+    // JSON形式(fmt=json3)を強制して取得しやすくする
+    const baseUrl = track.baseUrl;
+    const jsonUrl = baseUrl.includes('fmt=')
+      ? baseUrl.replace(/fmt=[^&]+/, 'fmt=json3')
+      : `${baseUrl}&fmt=json3`;
+
+    const jsonRes = await fetch(jsonUrl);
+    const jsonData = await jsonRes.json();
+
+    if (!jsonData.events) {
+      throw new Error('Invalid JSON transcript format (no events)');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const events = jsonData.events as any[];
+
+    return events
+      .map((event) => {
+        if (!event.segs) return '';
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return event.segs.map((seg: any) => seg.utf8).join('');
+      })
+      .join(' ')
+      .replace(/\s+/g, ' '); // 余分な空白削除
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,6 +5,7 @@ import { CacheRepository } from '../infrastructure/cache-repository.js';
 import { YouTubeService } from '../infrastructure/youtube-service.js';
 import { CalendarService } from '../infrastructure/calendar-service.js';
 import { SpreadsheetService } from '../infrastructure/spreadsheet-service.js';
+import { SummarizeService } from '../infrastructure/summarize-service.js';
 import WelcomeScreen from './screens/Welcome.js';
 import CreatorListScreen from './screens/CreatorList.js';
 import ActivityFeedScreen from './screens/ActivityFeed.js';
@@ -24,6 +25,7 @@ interface AppProps {
   week?: boolean;
   disableColor?: boolean;
   clean?: boolean;
+  summary?: boolean;
 }
 
 type ScreenName = 'init' | 'add' | 'remove' | 'list' | 'check' | 'schedule';
@@ -40,6 +42,7 @@ const App: React.FC<AppProps> = ({
   week,
   disableColor,
   clean,
+  summary,
 }) => {
   // Dependency Injection (Simple)
   const [configRepo] = useState(() => new ConfigRepository());
@@ -51,6 +54,7 @@ const App: React.FC<AppProps> = ({
   const [spreadsheetService] = useState(
     () => new SpreadsheetService(cacheRepo),
   );
+  const [summarizeService] = useState(() => new SummarizeService());
 
   // Navigation State
   const [currentScreen, setCurrentScreen] = useState<ScreenName>(
@@ -194,6 +198,8 @@ const App: React.FC<AppProps> = ({
           debug={debug}
           refresh={refresh}
           disableColor={disableColor}
+          summary={summary}
+          summarizeService={summarizeService}
         />
       );
     case 'schedule':

--- a/stats_bot/update_sheet.py
+++ b/stats_bot/update_sheet.py
@@ -112,7 +112,7 @@ def main():
             video_count = int(stats['videoCount'])
             view_count = int(stats['viewCount'])
 
-            print(f"取得成功: {name} ({member_id}) - 登録者数: {subscribers}")
+            print(f"取得成功: {name} ({member_id}) - 登録者数: {subscribers}, 動画数: {video_count}, 総再生数: {view_count}")
 
             # 最終行にデータを追加 [日付, 登録者数, 動画数, 総再生数]
             # IDごとのシートになったので名前カラムは削除してシンプルにしました


### PR DESCRIPTION
closes #89 

- Add `--summary` (`-s`) option to `check` command
- Integrate [init](cci:1://file:///e:/source/repos/valiv-cli/src/ui/screens/Welcome.tsx:43:4-62:6) command with Gemini API Key configuration
- Implement [SummarizeService](cci:2://file:///e:/source/repos/valiv-cli/src/infrastructure/summarize-service.ts:4:0-172:1) using `gemini-3-flash-preview`
- Use `youtube-transcript-plus` with manual fallback for robust caption fetching
- UI: Show summary on interactively selecting a video in the list
- UI: Display granular progress status (fetching transcript / generating summary)